### PR TITLE
Fix loading of ConfigParser

### DIFF
--- a/pepper/cli.py
+++ b/pepper/cli.py
@@ -10,13 +10,10 @@ import os
 import textwrap
 import getpass
 import time
-try:
-    # Python 3
-    from configparser import ConfigParser
-except ImportError:
-    # Python 2
-    import ConfigParser
-
+if sys.version_info >= (3,0):
+        from configparser import ConfigParser
+else:
+        import ConfigParser
 try:
     input = raw_input
 except NameError:


### PR DESCRIPTION
This fixes loading the correct version of ConfigParser if both, Python2.7 and Python3 are installed
(class ConfigParser has no attribute 'RawConfigParser' )